### PR TITLE
Removed "Characters" keyword to match grDevices

### DIFF
--- a/src/ttf2pt1/ttf2pt1.c
+++ b/src/ttf2pt1/ttf2pt1.c
@@ -2390,7 +2390,7 @@ main(
     fprintf(afm_file, "FamilyName %s\n", fontm.name_family);
     fprintf(afm_file, "Weight %s\n", fontm.name_style);
     fprintf(afm_file, "Version %s\n", fontm.name_version);
-    fprintf(afm_file, "Characters %d\n", nchars);
+    /* fprintf(afm_file, "Characters %d\n", nchars); */
     fprintf(afm_file, "ItalicAngle %.1f\n", italic_angle);
 
     fprintf(afm_file, "Ascender %d\n", iscale(fontm.ascender));


### PR DESCRIPTION
The file R/src/library/grDevices/src in the R project has a list of all acceptable keywords.  The list does not contain "Characters", which does appear in afm files generated by Rttf3pt1.  The result is an ugly warning every time a font is used.  This change suppresses the addition of this keyword.
