### PR TITLE
Add LDFLAGS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,10 @@
 CC = `"$(R_HOME)/bin/R" CMD config CC`
 CFLAGS = `"$(R_HOME)/bin/R" CMD config CFLAGS`
-
+LDFLAGS = `"$(R_HOME)/bin/R" CMD config LDFLAGS`
 # Run make in subdirs
 all:
 	echo "make ttf2pt1 in ttf2pt1/ ..."
-	(cd ttf2pt1; $(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" ttf2pt1)
+	(cd ttf2pt1; $(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" LIBS="$(LDFLAGS)" ttf2pt1)
 
 clean:
 	echo "make veryclean in ttf2pt1/ ..."


### PR DESCRIPTION
Hi,

if either `$(CC)` or `$(CFLAGS)` are non-standard, in all likelihood `$(LDFLAGS)` is as well. This fixed a compilation issue for this package with a non-default compiler.

Best regards,
Stefan