### PR TITLE
Fix segfault

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rttf2pt1
 Title: 'ttf2pt1' Program
-Version: 1.3.11
+Version: 1.3.11.9000
 Author: Winston Chang,
     Andrew Weeks,
     Frank M. Siegert,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+Version 1.3.11.9000
+--------------
+* Closed #10, #19: Reverted some changes from #13 which could cause `ttf2pt1` to crashe, and cause the message `No FontName. Skipping.` to appear. (#20)
+
 Version 1.3.11
 --------------
 

--- a/src/ttf2pt1/pt1.c
+++ b/src/ttf2pt1/pt1.c
@@ -4937,8 +4937,7 @@ fcrossraysge(
 	GENTRY *ge2,
 	double *max1,
 	double *max2,
-	double** crossdot
-	// double crossdot[2][2]
+	double crossdot[2][2]
 )
 {
 	ray[0].x1 = ge1->prev->fx3;
@@ -4958,7 +4957,7 @@ fcrossraysge(
 	}
 	ray[1].maxp = max2;
 
-	return fcrossraysxx((double (*)[2])crossdot);
+	return fcrossraysxx(crossdot);
 }
 
 /* debugging printout functions */
@@ -6048,7 +6047,7 @@ fconcisecontour(
 
 			fnormalizege(&tpge);
 			fnormalizege(&tnge);
-			if( fcrossraysge(&tpge, &tnge, NULL, NULL, (double**)&apcv[1]) ) {
+			if( fcrossraysge(&tpge, &tnge, NULL, NULL, &apcv[1]) ) {
 				apcv[0][X] = tpge.bkwd->fx3;
 				apcv[0][Y] = tpge.bkwd->fy3;
 				/* apcv[1] and apcv[2] were filled by fcrossraysge() */

--- a/src/ttf2pt1/pt1.c
+++ b/src/ttf2pt1/pt1.c
@@ -4993,8 +4993,7 @@ printseg(
 
 double
 fdotsegdist2(
-	double** seg,
-	// double seg[2][2 /*X,Y*/],
+	double seg[2][2 /*X,Y*/],
 	double dot[2 /*X,Y*/]
 )
 {
@@ -5217,13 +5216,13 @@ fdotcurvdist2(
 		/* the nearest segment must include the nearest dot */
 		if(id1==0) {
 			dots[d].seg = 0;
-			dots[d].dist2 = fdotsegdist2((double**)&cvd[0], dots[d].p);
+			dots[d].dist2 = fdotsegdist2(&cvd[0], dots[d].p);
 		} else if(id1==NAPSECT) {
 			dots[d].seg = NAPSECT-1;
-			dots[d].dist2 = fdotsegdist2((double**)&cvd[NAPSECT-1], dots[d].p);
+			dots[d].dist2 = fdotsegdist2(&cvd[NAPSECT-1], dots[d].p);
 		} else {
-			dist1 = fdotsegdist2((double**)&cvd[id1], dots[d].p);
-			dist2 = fdotsegdist2((double**)&cvd[id1-1], dots[d].p);
+			dist1 = fdotsegdist2(&cvd[id1], dots[d].p);
+			dist2 = fdotsegdist2(&cvd[id1-1], dots[d].p);
 			if(dist2 < dist1) {
 				dots[d].seg = id1-1;
 				dots[d].dist2 = dist2;
@@ -5470,7 +5469,7 @@ fjointsin2(
 		d[0][axis] = -( d[1][axis] *= scale1 );
 		d[2][axis] *= scale2;
 	}
-	return fdotsegdist2((double**)d, d[2]);
+	return fdotsegdist2(d, d[2]);
 }
 
 #if 0
@@ -5662,7 +5661,7 @@ fanalyzege(
 			dots[1][i] = ge->fpoints[i][2];
 			dots[2][i] = fcvval(ge, i, 0.5);
 		}
-		avsd2 = fdotsegdist2((double**)dots, dots[2]);
+		avsd2 = fdotsegdist2(dots, dots[2]);
 		if(avsd2 <= CVEPS2) {
 			gex->flags |= GEXF_FLAT;
 		}
@@ -5822,7 +5821,7 @@ try_flatboth:
 			dots[1][i] = nge->fpoints[i][2];
 			dots[2][i] = ge->fpoints[i][2];
 		}
-		if( fdotsegdist2((double**)dots, dots[2]) <= CVEPS2)
+		if( fdotsegdist2(dots, dots[2]) <= CVEPS2)
 			gex->flags |= GEXF_JLINE;
 	}
 }
@@ -6202,7 +6201,7 @@ next:
 				}
 				ndots++;
 				for(i=0; i<ndots; i++) {
-					avsd2 = fdotsegdist2((double**)apcv, dots[i].p);
+					avsd2 = fdotsegdist2(apcv, dots[i].p);
 					if(avsd2 > CVEPS2)
 						break;
 				}
@@ -6230,7 +6229,7 @@ next:
 				}
 				ndots++;
 				for(i=0; i<ndots; i++) {
-					avsd2 = fdotsegdist2((double**)apcv, dots[i].p);
+					avsd2 = fdotsegdist2(apcv, dots[i].p);
 					if(avsd2 > CVEPS2)
 						break;
 				}

--- a/src/ttf2pt1/pt1.h
+++ b/src/ttf2pt1/pt1.h
@@ -252,7 +252,6 @@ void print_kerning( FILE *afm_file);
 int fcrossrayscv( double curve[4][2], double *max1, double *max2);
 int fcrossraysge( GENTRY *ge1, GENTRY *ge2, double *max1, double *max2,
 	double crossdot[2][2]);
-// double fdotsegdist2( double seg[2][2], double dot[2]);
-double fdotsegdist2( double** seg, double dot[2]);
+double fdotsegdist2( double seg[2][2], double dot[2]);
 double fdotcurvdist2( double curve[4][2], struct dot_dist *dots, int ndots, double *maxp);
 void fapproxcurve( double cv[4][2], struct dot_dist *dots, int ndots);

--- a/src/ttf2pt1/pt1.h
+++ b/src/ttf2pt1/pt1.h
@@ -250,10 +250,8 @@ void addkernpair( unsigned id1, unsigned id2, int unscval);
 void print_kerning( FILE *afm_file);
 
 int fcrossrayscv( double curve[4][2], double *max1, double *max2);
-// int fcrossraysge( GENTRY *ge1, GENTRY *ge2, double *max1, double *max2,
-// 	double crossdot[2][2]);
 int fcrossraysge( GENTRY *ge1, GENTRY *ge2, double *max1, double *max2,
-	double** crossdot);
+	double crossdot[2][2]);
 // double fdotsegdist2( double seg[2][2], double dot[2]);
 double fdotsegdist2( double** seg, double dot[2]);
 double fdotcurvdist2( double curve[4][2], struct dot_dist *dots, int ndots, double *maxp);


### PR DESCRIPTION
Closes #10, closes #19 (see that issue for more details).

The changes in #13 caused a segfault in some cases. Those changes were made due to a spurious compiler warning, but I think they can be reverted now that newer versions of gcc have fixed that warning.