### PR TITLE
Fix `-Wstringop-overflow=` warnings

### DIFF
--- a/src/ttf2pt1/pt1.c
+++ b/src/ttf2pt1/pt1.c
@@ -4907,7 +4907,8 @@ fcrossraysxx(
 
 int
 fcrossrayscv(
-	double curve[4][2 /*X,Y*/],
+	// double curve[4][2 /*X,Y*/],
+	double (*curve)[2 /*X,Y*/],
 	double *max1,
 	double *max2
 )
@@ -4937,7 +4938,8 @@ fcrossraysge(
 	GENTRY *ge2,
 	double *max1,
 	double *max2,
-	double crossdot[2][2]
+	// double crossdot[2][2]
+	double (*crossdot)[2]
 )
 {
 	ray[0].x1 = ge1->prev->fx3;
@@ -4993,7 +4995,8 @@ printseg(
 
 double
 fdotsegdist2(
-	double seg[2][2 /*X,Y*/],
+	// double seg[2][2 /*X,Y*/],
+	double (*seg)[2 /*X,Y*/],
 	double dot[2 /*X,Y*/]
 )
 {
@@ -5085,7 +5088,8 @@ fdotsegdist2(
 
 double
 fdotcurvdist2(
-	double curve[4][2 /*X,Y*/ ],
+	// double curve[4][2 /*X,Y*/ ],
+	double (*curve)[2 /*X,Y*/ ],
 	struct dot_dist *dots,
 	int ndots, /* number of entries in dots */
 	double *maxp
@@ -5267,7 +5271,8 @@ fdotcurvdist2(
 
 void
 fapproxcurve(
-	double cv[4][2 /*X,Y*/ ], /* points 0-3 are passed in, points 1,2 - out */
+	// double cv[4][2 /*X,Y*/ ], /* points 0-3 are passed in, points 1,2 - out */
+	double (*cv)[2 /*X,Y*/ ], /* points 0-3 are passed in, points 1,2 - out */
 	struct dot_dist *dots, /* the dots to approximate - distances returned 
 		* there may be invalid */
 	int ndots

--- a/src/ttf2pt1/pt1.h
+++ b/src/ttf2pt1/pt1.h
@@ -249,9 +249,15 @@ void docorrectwidth(void);
 void addkernpair( unsigned id1, unsigned id2, int unscval);
 void print_kerning( FILE *afm_file);
 
-int fcrossrayscv( double curve[4][2], double *max1, double *max2);
+//int fcrossrayscv( double curve[4][2], double *max1, double *max2);
+int fcrossrayscv( double (*curve)[2], double *max1, double *max2);
+// int fcrossraysge( GENTRY *ge1, GENTRY *ge2, double *max1, double *max2,
+// 	double crossdot[2][2]);
 int fcrossraysge( GENTRY *ge1, GENTRY *ge2, double *max1, double *max2,
-	double crossdot[2][2]);
-double fdotsegdist2( double seg[2][2], double dot[2]);
-double fdotcurvdist2( double curve[4][2], struct dot_dist *dots, int ndots, double *maxp);
-void fapproxcurve( double cv[4][2], struct dot_dist *dots, int ndots);
+	double (*crossdot)[2]);
+// double fdotsegdist2( double seg[2][2], double dot[2]);
+double fdotsegdist2( double (*seg)[2], double dot[2]);
+// double fdotcurvdist2( double curve[4][2], struct dot_dist *dots, int ndots, double *maxp);
+double fdotcurvdist2( double (*curve)[2], struct dot_dist *dots, int ndots, double *maxp);
+// void fapproxcurve( double cv[4][2], struct dot_dist *dots, int ndots);
+void fapproxcurve( double (*cv)[2], struct dot_dist *dots, int ndots);


### PR DESCRIPTION
This is another attempt to fix the `-Wstringop-overflow=` warnings flagged by CRAN.
Also see #13, #19, #20.