### PR TITLE
Use LDFLAGS when linking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,11 @@
 CC = `"$(R_HOME)/bin/R" CMD config CC`
 CFLAGS = `"$(R_HOME)/bin/R" CMD config CFLAGS`
+LDFLAGS = `"$(R_HOME)/bin/R" CMD config LDFLAGS`
 
 # Run make in subdirs
 all:
 	echo "make ttf2pt1 in ttf2pt1/ ..."
-	(cd ttf2pt1; $(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" ttf2pt1)
+	(cd ttf2pt1; $(MAKE) CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" ttf2pt1)
 
 clean:
 	echo "make veryclean in ttf2pt1/ ..."

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -1,5 +1,6 @@
 CC = `"$(R_HOME)/bin/R" CMD config CC`
 CFLAGS = `"$(R_HOME)/bin/R" CMD config CFLAGS`
+LDFLAGS = `"$(R_HOME)/bin/R" CMD config LDFLAGS`
 
 # Disable a bunch of warnings because they cause problems with R CMD check
 # as of R 3.1.1.
@@ -13,7 +14,7 @@ TTF2PT1_CFLAGS = $(CFLAGS) $(ARCH) -DWINDOWS \
 # Makeconf is not sourced for Makefile.win, so it needs to be explicitly included.
 all:
 	echo "make ttf2pt1 in ttf2pt1/ ..."
-	(cd ttf2pt1; $(MAKE) -f "${R_HOME}/etc${R_ARCH}/Makeconf" -f Makefile CC="$(CC)" CFLAGS="$(TTF2PT1_CFLAGS)" ttf2pt1)
+	(cd ttf2pt1; $(MAKE) -f "${R_HOME}/etc${R_ARCH}/Makeconf" -f Makefile CC="$(CC)" CFLAGS="$(TTF2PT1_CFLAGS)" LDFLAGS="$(LDFLAGS)" ttf2pt1)
 
 clean:
 	echo "make veryclean in ttf2pt1/ ..."

--- a/src/ttf2pt1/Makefile
+++ b/src/ttf2pt1/Makefile
@@ -203,7 +203,7 @@ runt1asm.o: runt1asm.c global.h
 	$(CC) $(CFLAGS) $(CFLAGS_EXTT1ASM) -c runt1asm.c
 
 ttf2pt1:	ttf2pt1.o pt1.o runt1asm.o ttf.o ft.o bdf.o bitmap.o
-	$(CC) $(CFLAGS) -o ttf2pt1 ttf2pt1.o pt1.o runt1asm.o ttf.o ft.o bdf.o bitmap.o $(LIBS)
+	$(CC) $(LDFLAGS) -o ttf2pt1 ttf2pt1.o pt1.o runt1asm.o ttf.o ft.o bdf.o bitmap.o $(LIBS)
 
 CHANGES: CHANGES.html
 	scripts/unhtml <CHANGES.html >CHANGES


### PR DESCRIPTION
The `LDFLAGS` should be passed to the linker instead of `CFLAGS`.

Almost the same change was requested in #11 but that used the `LIBS` variable, while this patch passes the flags simply as `LDFLAGS` and also updates the Windows Makefile. This has been tested only on Linux though.